### PR TITLE
Added PopulateDefaultsMachineDeployment to sync

### DIFF
--- a/pkg/controller/machinedeployment/sync.go
+++ b/pkg/controller/machinedeployment/sync.go
@@ -474,6 +474,8 @@ func updateMachineDeployment(c client.Client, d *clusterv1alpha1.MachineDeployme
 		if err := c.Get(context.Background(), types.NamespacedName{Namespace: d.Namespace, Name: d.Name}, d); err != nil {
 			return err
 		}
+
+		clusterv1alpha1.PopulateDefaultsMachineDeployment(d)
 		// Apply modifications
 		modify(d)
 		// Update the machineDeployment


### PR DESCRIPTION
With missing this, there are a couple of nil pointer panics, because the
content to wich `d` (or `deployment`) is pointing to, is changed before
storing it again. Subsequent code assumes `Strategy` to be there, no
matter wether or not it is already in the DB.

The result also is, that Spec.Strategy is stored with defaults in the API

Feel free to just copy the line out of the code and close this PR. Just
thought this is easier than trying to describe what to do ;)